### PR TITLE
Update plonk-lookup.md

### DIFF
--- a/src/plonk-intro-cn/plonk-lookup.md
+++ b/src/plonk-intro-cn/plonk-lookup.md
@@ -205,7 +205,7 @@ $$
 \begin{split}
 &\prod_i{(1+\beta)(f_i+\gamma)(t_i+\beta\cdot t_{i+1}+(1+\beta)\gamma)} \\
 =&\prod_i
-{(s_i+\beta\cdot s_{i+1}+\gamma)}
+{(s_i+\beta\cdot s_{i+1}+(1+\beta)\gamma)}
 \end{split}
 $$
 
@@ -360,13 +360,13 @@ $$
 通过向 Verifier 要一个随机挑战数 $\eta$，我们可以把计算表格横向折叠起来：
 
 $$
-\vec{t} = \vec{t}_1+\eta\cdot\vec{t}_2+\eta^2\cdot\vec{t}_2
+\vec{t} = \vec{t}_1+\eta\cdot\vec{t}_2+\eta^2\cdot\vec{t}_3
 $$
 
 同样，Prover 在证明过程中，也将查询记录横向折叠起来：
 
 $$
-\vec{f} = \vec{f}_1+\eta\cdot\vec{f}_2+\eta^2\cdot\vec{f}_2
+\vec{f} = \vec{f}_1+\eta\cdot\vec{f}_2+\eta^2\cdot\vec{f}_3
 $$
 
 接下来，Prover 和 Verifier 可以利用单列表格查询协议（ Plookup 协议或 Halo2-lookup 协议）完成证明过程。


### PR DESCRIPTION
# 理解 PLONK（七）：Lookup Gate
## Plookup方案
在 Plookup 论文方案中，调换了 $\beta$ 和 $\gamma$顺序后为：

$$
\{(s_i+\gamma) + \beta (s_{i+1}+\gamma)\}=\{(t_i + \gamma) + \beta (t_{i+1}+\gamma)\}\cup\{(f_i+\gamma)+ \beta(f_i+\gamma)\}
$$

因此得到的 Grand Product 中关于 $s_i$ 项应该为

$$
\prod_i{(s_i+\beta\cdot s_{i+1}+(1+\beta)\gamma)}
$$

## 多列表格与多表格扩展
在折叠向量中的最后一个角标有误，对向量 $(\vec{t}_1, \vec{t}_2, \vec{t}_3)$ 与 $(\vec{f}_1,\vec{f}_2,\vec{f}_3)$ 的折叠应该为：

$$
\vec{t} = \vec{t}_1+\eta\cdot\vec{t}_2+\eta^2\cdot\vec{t}_3
$$

$$
\vec{f} = \vec{f}_1+\eta\cdot\vec{f}_2+\eta^2\cdot\vec{f}_3
$$
